### PR TITLE
ADO-3233 Implement the /generatePortalForm endpoint on kiln-api

### DIFF
--- a/server/api/controllers/communications.controller.ts
+++ b/server/api/controllers/communications.controller.ts
@@ -152,6 +152,29 @@ export class CommunicationsController {
     }
   }
 
+  async generatePortalForm(req: Request, res: Response): Promise<void> {
+    const originalServer = req.headers['x-original-server'] as string;
+    const { token, username, ...params } = req.body;
+
+    const authHeader = req.headers.authorization;
+    const authToken =
+      token ||
+      (authHeader?.startsWith('Bearer ')
+        ? authHeader.substring(7)
+        : authHeader);
+
+    const result = await ICMService.generatePortalForm(
+      { ...params, username, originalServer },
+      authToken
+    );
+
+    if (result.success) {
+      res.status(200).json(result.data);
+    } else {
+      res.status(result.status || 500).json({ error: result.error });
+    }
+  }
+
   generatePDFFromJson(req: Request, res: Response): void {
     res.json({ endpoint: 'generatePDFFromJson', payload: req.body });
   }

--- a/server/api/controllers/router.ts
+++ b/server/api/controllers/router.ts
@@ -39,6 +39,9 @@ router.post('/generatePDFFromJson', (req, res) =>
 router.post('/generateNewTemplate', (req, res) =>
   CommunicationsController.generateNewTemplate(req, res)
 );
+router.post('/generatePortalForm', (req, res) =>
+  CommunicationsController.generatePortalForm(req, res)
+);
 
 // Kiln Renderer Routes
 router.get('/view', (req, res) => RendererController.viewForm(req, res));

--- a/server/api/services/icm.client.ts
+++ b/server/api/services/icm.client.ts
@@ -251,4 +251,29 @@ export class ICMClient {
       return this.handleBlobError(error, 'pdfRender');
     }
   }
+
+  async generatePortalForm(
+    payload: Record<string, any>,
+    originalServer?: string
+  ) {
+    const url = (process.env.COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL || '').trim();
+    if (!url) {
+      throw new Error(
+        'COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL environment variable is required'
+      );
+    }
+
+    const timeout = parseInt(process.env.COMM_API_TIMEOUT || '30000', 10);
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (originalServer) headers['X-Original-Server'] = originalServer;
+
+    try {
+      const res = await axios.post(url, payload, { headers, timeout });
+      return this.createJsonResponse(res);  
+    } catch (error) {
+      return this.handleJsonError(error, 'generatePortalForm');
+    }
+  }
+
 }

--- a/server/api/services/icm.service.ts
+++ b/server/api/services/icm.service.ts
@@ -106,8 +106,8 @@ export class ICMService {
       error instanceof Error
         ? error.message
         : typeof error === 'string'
-        ? error
-        : 'Unknown error occurred';
+          ? error
+          : 'Unknown error occurred';
 
     L.error(errorMessage, error);
 
@@ -365,6 +365,38 @@ export class ICMService {
         error,
         'Failed to generate PDF'
       ) as PdfRenderResult;
+    }
+  }
+
+  async generatePortalForm(
+    data: { username?: string; originalServer?: string;[k: string]: any },
+    token?: string
+  ): Promise<{ success: boolean; data?: any; error?: string; status?: number }> {
+    try {
+      const { username, originalServer, ...params } = data || {};
+      const payload: Record<string, any> = { ...params };
+
+      if (token && String(token).trim()) {
+        payload.token = token;
+      } else if (username && String(username).trim()) {
+        payload.username = username;
+      } else {
+        return {
+          success: false,
+          status: 401,
+          error:
+            'Authentication required: either token or username must be provided',
+        };
+      }
+
+      const resp = await this.icmClient.generatePortalForm(payload, originalServer);
+
+      return this.handleResponse(
+        resp,
+        'Error generating portal form. Please try again.'
+      );
+    } catch (err) {
+      return this.handleError(err, 'Failed to generate portal form');
     }
   }
 }

--- a/server/common/api.yml
+++ b/server/common/api.yml
@@ -299,3 +299,30 @@ paths:
         404:
           description: Example not found
 
+  /generatePortalForm:
+    post:
+      tags:
+        - Communications Layer
+      summary: Generate portal form
+      description: Generates a portal form JSON payload.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: payload
+          required: true
+          schema:
+            type: object
+      responses:
+        200:
+          description: Portal form generated
+          schema:
+            type: object
+        400:
+          description: Bad request
+        401:
+          description: Unauthorized
+        500:
+          description: Internal server error

--- a/test/communications.controller.test.ts
+++ b/test/communications.controller.test.ts
@@ -11,6 +11,7 @@ describe('Communications Controller', () => {
   let loadSavedJsonStub: sinon.SinonStub;
   let generateFormStub: sinon.SinonStub;
   let pdfRenderStub: sinon.SinonStub;
+  let generatePortalFormStub: sinon.SinonStub;
 
   beforeEach(() => {
     loadICMDataStub = sinon.stub(ICMService, 'loadICMData');
@@ -18,6 +19,7 @@ describe('Communications Controller', () => {
     loadSavedJsonStub = sinon.stub(ICMService, 'loadSavedJson');
     generateFormStub = sinon.stub(ICMService, 'generateForm');
     pdfRenderStub = sinon.stub(ICMService, 'pdfRender');
+    generatePortalFormStub = sinon.stub(ICMService, 'generatePortalForm');
   });
 
   afterEach(() => {
@@ -901,4 +903,192 @@ describe('Communications Controller', () => {
       });
     });
   });
+
+  describe('generatePortalForm endpoint', () => {
+    it('should successfully generate portal form with username', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-123',
+      };
+
+      generatePortalFormStub.resolves({
+        success: true,
+        data: { save_data: { id: 'pf-123', built: true }, status: 'created' },
+      });
+
+      const response = await request(Server)
+        .post('/api/generatePortalForm')
+        .send(testData)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body).to.deep.equal({
+        save_data: { id: 'pf-123', built: true },
+        status: 'created',
+      });
+
+      expect(generatePortalFormStub.calledOnce).to.be.true;
+      const [data, token] = generatePortalFormStub.getCall(0).args;
+      expect(data).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-123',
+        username: 'testuser',
+        originalServer: undefined,
+      });
+      expect(token).to.be.undefined;
+    });
+
+    it('should successfully generate portal form with token in Authorization header', async () => {
+      const testData = {
+        formType: 'portal',
+        templateId: 'tpl-456',
+      };
+
+      generatePortalFormStub.resolves({
+        success: true,
+        data: { save_data: { id: 'pf-456' }, ok: true },
+      });
+
+      const response = await request(Server)
+        .post('/api/generatePortalForm')
+        .set('Authorization', 'Bearer header-token-123')
+        .send(testData)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body).to.deep.equal({ save_data: { id: 'pf-456' }, ok: true });
+
+      const [data, token] = generatePortalFormStub.getCall(0).args;
+      expect(data).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-456',
+        username: undefined,
+        originalServer: undefined,
+      });
+      expect(token).to.equal('header-token-123');
+    });
+
+    it('should prioritize token from request body over Authorization header', async () => {
+      const testData = {
+        token: 'body-token-999',
+        formType: 'portal',
+        templateId: 'tpl-priority',
+      };
+
+      generatePortalFormStub.resolves({
+        success: true,
+        data: { save_data: { id: 'pf-priority' } },
+      });
+
+      const response = await request(Server)
+        .post('/api/generatePortalForm')
+        .set('Authorization', 'Bearer header-token-should-be-ignored')
+        .send(testData)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body).to.deep.equal({ save_data: { id: 'pf-priority' } });
+
+      const [data, token] = generatePortalFormStub.getCall(0).args;
+      expect(token).to.equal('body-token-999');
+      expect(data).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-priority',
+        username: undefined,
+        originalServer: undefined,
+      });
+    });
+
+    it('should pass through originalServer from headers', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-os',
+      };
+
+      generatePortalFormStub.resolves({
+        success: true,
+        data: { save_data: { id: 'pf-os' } },
+      });
+
+      await request(Server)
+        .post('/api/generatePortalForm')
+        .set('x-original-server', 'https://icm-dev.internal')
+        .send(testData)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      const [data] = generatePortalFormStub.getCall(0).args;
+      expect(data.originalServer).to.equal('https://icm-dev.internal');
+    });
+
+    it('should return 401 when service reports authentication error', async () => {
+      generatePortalFormStub.resolves({
+        success: false,
+        status: 401,
+        error: 'Authentication required',
+      });
+
+      const response = await request(Server)
+        .post('/api/generatePortalForm')
+        // send minimum fields required by your swagger schema so validator passes
+        .send({ formType: 'portal', templateId: 'tpl-unauth' })
+        .expect('Content-Type', /json/)
+        .expect(401);
+
+      expect(response.body).to.deep.equal({ error: 'Authentication required' });
+    });
+
+    it('should handle service error with default status 500', async () => {
+      generatePortalFormStub.resolves({
+        success: false,
+        error: 'Internal portal generation error',
+      });
+
+      const response = await request(Server)
+        .post('/api/generatePortalForm')
+        .send({ formType: 'portal', templateId: 'tpl-err' })
+        .expect('Content-Type', /json/)
+        .expect(500);
+
+      expect(response.body).to.deep.equal({
+        error: 'Internal portal generation error',
+      });
+    });
+
+    it('should pass through all request body parameters', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-777',
+        customField1: 'v1',
+        customField2: 2,
+        metadata: { source: 'api' },
+      };
+
+      generatePortalFormStub.resolves({
+        success: true,
+        data: { save_data: { id: 'pf-777' } },
+      });
+
+      await request(Server)
+        .post('/api/generatePortalForm')
+        .send(testData)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      const [data] = generatePortalFormStub.getCall(0).args;
+      expect(data).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-777',
+        customField1: 'v1',
+        customField2: 2,
+        metadata: { source: 'api' },
+        username: 'testuser',
+        originalServer: undefined,
+      });
+    });
+  });
+
 });

--- a/test/icm.client.test.ts
+++ b/test/icm.client.test.ts
@@ -205,12 +205,12 @@ describe('ICMClient', () => {
       process.env.COMM_API_TIMEOUT = '5000';
 
       const mockPayload = { formId: 'form-123', version: '1.0' };
-      const mockResponseData = { 
-        success: true, 
-        data: { 
+      const mockResponseData = {
+        success: true,
+        data: {
           savedJson: { field1: 'value1', field2: 'value2' },
           version: '1.0'
-        } 
+        }
       };
 
       axiosPostStub.resolves({
@@ -344,7 +344,7 @@ describe('ICMClient', () => {
       expect(axiosPostStub.calledOnce).to.be.true;
       expect(
         axiosPostStub.calledWith('https://api.example.com/icm/generate', mockPayload, {
-          headers: { 
+          headers: {
             'Content-Type': 'application/json',
             'X-Original-Server': originalServer
           },
@@ -439,7 +439,7 @@ describe('ICMClient', () => {
       // Arrange
       process.env.COMM_API_PDFTEMPLATE_ENDPOINT_URL =
         'https://api.example.com/pdf-service';
-      
+
       const mockPayload = { data: 'test' };
       const pdfTemplateId = 'my-template-456';
 
@@ -619,4 +619,106 @@ describe('ICMClient', () => {
       expect(blobData.equals(largePdfBuffer)).to.be.true;
     });
   });
+
+  describe('generatePortalForm', () => {
+    it('should throw error when COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL is not set', async () => {
+      delete process.env.COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL;
+
+      try {
+        await icmClient.generatePortalForm({ test: 'data' });
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).to.equal(
+          'COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL environment variable is required'
+        );
+      }
+    });
+
+    it('should make successful API call and return proper JSON response', async () => {
+      process.env.COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL =
+        'https://api.example.com/icm/generatePortalForm';
+      process.env.COMM_API_TIMEOUT = '5000';
+
+      const mockPayload = { formType: 'portal', data: { name: 'test' } };
+      const mockResponseData = {
+        save_data: { field1: 'v1', field2: 'v2' },
+        status: 'ok',
+      };
+
+      axiosPostStub.resolves({
+        status: 200,
+        data: mockResponseData,
+      });
+
+      const result = await icmClient.generatePortalForm(mockPayload);
+
+      expect(result.ok).to.be.true;
+      expect(result.status).to.equal(200);
+
+      const jsonData = await result.json();
+      expect(jsonData).to.deep.equal(mockResponseData);
+
+      expect(axiosPostStub.calledOnce).to.be.true;
+      expect(
+        axiosPostStub.calledWith(
+          'https://api.example.com/icm/generatePortalForm',
+          mockPayload,
+          {
+            headers: { 'Content-Type': 'application/json' },
+            timeout: 5000,
+          }
+        )
+      ).to.be.true;
+    });
+
+    it('should include X-Original-Server header when provided', async () => {
+      process.env.COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL =
+        'https://api.example.com/icm/generatePortalForm';
+      process.env.COMM_API_TIMEOUT = '5000';
+
+      const mockPayload = { formType: 'portal', data: { name: 'x' } };
+      const originalServer = 'https://icm-dev.internal';
+      axiosPostStub.resolves({ status: 200, data: { ok: true } });
+
+      await icmClient.generatePortalForm(mockPayload, originalServer);
+
+      expect(axiosPostStub.calledOnce).to.be.true;
+      expect(
+        axiosPostStub.calledWith(
+          'https://api.example.com/icm/generatePortalForm',
+          mockPayload,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Original-Server': originalServer,
+            },
+            timeout: 5000,
+          }
+        )
+      ).to.be.true;
+    });
+
+    it('should handle axios error responses properly (JSON error payload)', async () => {
+      process.env.COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL =
+        'https://api.example.com/icm/generatePortalForm';
+      process.env.COMM_API_TIMEOUT = '5000';
+
+      const mockPayload = { formType: 'portal', data: { name: 'bad' } };
+      const mockErrorResponse = { error: 'Bad Request', message: 'Invalid data' };
+
+      const axiosError: any = new Error('Request failed');
+      axiosError.response = { status: 400, data: mockErrorResponse };
+
+      axiosPostStub.rejects(axiosError);
+
+      const result = await icmClient.generatePortalForm(mockPayload);
+
+      expect(result.ok).to.be.false;
+      expect(result.status).to.equal(400);
+      const jsonData = await result.json();
+      expect(jsonData).to.deep.equal(mockErrorResponse);
+    });
+  });
+
+
 });

--- a/test/icm.service.test.ts
+++ b/test/icm.service.test.ts
@@ -938,4 +938,210 @@ describe('ICMService', () => {
       expect(templateId).to.equal('template_with-special.chars@123');
     });
   });
+
+  describe('generatePortalForm', () => {
+    it('should successfully generate portal form with token', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-123',
+        originalServer: 'https://original.example.com',
+        extra: 'value',
+      };
+
+      const mockResponse = {
+        ok: true,
+        json: sinon.stub().resolves({
+          save_data: { built: true, id: 'pf-123' },
+          status: 'created',
+        }),
+      };
+
+      icmClientStub.generatePortalForm.resolves(mockResponse as any);
+
+      const result = await icmService.generatePortalForm(testData, 'test-token');
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal({
+        save_data: { built: true, id: 'pf-123' },
+        status: 'created',
+      });
+      expect(icmClientStub.generatePortalForm.calledOnce).to.be.true;
+
+      const [calledPayload, originalServer] =
+        icmClientStub.generatePortalForm.getCall(0).args;
+
+      expect(calledPayload).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-123',
+        extra: 'value',
+        token: 'test-token',
+      });
+      expect(originalServer).to.equal('https://original.example.com');
+    });
+
+    it('should successfully generate portal form with username when no token provided', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-456',
+      };
+
+      const mockResponse = {
+        ok: true,
+        json: sinon.stub().resolves({ save_data: { ok: true } }),
+      };
+
+      icmClientStub.generatePortalForm.resolves(mockResponse as any);
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal({ save_data: { ok: true } });
+
+      const [calledPayload, originalServer] =
+        icmClientStub.generatePortalForm.getCall(0).args;
+
+      expect(calledPayload).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-456',
+        username: 'testuser',
+      });
+      expect(originalServer).to.be.undefined;
+    });
+
+    it('should return 401 when neither token nor username is provided', async () => {
+      const testData = {
+        formType: 'portal',
+        templateId: 'tpl-789',
+      };
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal(
+        'Authentication required: either token or username must be provided'
+      );
+      expect(result.status).to.equal(401);
+      expect(icmClientStub.generatePortalForm.called).to.be.false;
+    });
+
+    it('should return 401 when username is empty string', async () => {
+      const testData = {
+        username: '   ',
+        formType: 'portal',
+        templateId: 'tpl-000',
+      };
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal(
+        'Authentication required: either token or username must be provided'
+      );
+      expect(result.status).to.equal(401);
+      expect(icmClientStub.generatePortalForm.called).to.be.false;
+    });
+
+    it('should handle ICM client API error responses (JSON)', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'bad-template',
+      };
+
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        json: sinon.stub().resolves({ error: 'Invalid template' }),
+      };
+
+      icmClientStub.generatePortalForm.resolves(mockResponse as any);
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal('Invalid template');
+      expect(result.status).to.equal(400);
+    });
+
+    it('should handle ICM client API error responses with default message', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-err',
+      };
+
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: sinon.stub().resolves({}),
+      };
+
+      icmClientStub.generatePortalForm.resolves(mockResponse as any);
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal('Error generating portal form. Please try again.');
+      expect(result.status).to.equal(500);
+    });
+
+    it('should handle ICM client exceptions', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-ex',
+      };
+
+      const error = new Error('Network connection failed');
+      icmClientStub.generatePortalForm.rejects(error);
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal(
+        'Failed to generate portal form: Network connection failed'
+      );
+      expect(result.status).to.equal(500);
+    });
+
+    it('should pass through additional parameters and originalServer', async () => {
+      const testData = {
+        username: 'testuser',
+        formType: 'portal',
+        templateId: 'tpl-123',
+        custom1: 'A',
+        custom2: 42,
+        originalServer: 'https://icm-dev.internal',
+      };
+
+      const mockResponse = {
+        ok: true,
+        json: sinon.stub().resolves({ save_data: { custom: true } }),
+      };
+
+      icmClientStub.generatePortalForm.resolves(mockResponse as any);
+
+      const result = await icmService.generatePortalForm(testData);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.deep.equal({ save_data: { custom: true } });
+      expect(icmClientStub.generatePortalForm.calledOnce).to.be.true;
+
+      const [calledPayload, originalServer] =
+        icmClientStub.generatePortalForm.getCall(0).args;
+
+      expect(calledPayload).to.deep.equal({
+        formType: 'portal',
+        templateId: 'tpl-123',
+        custom1: 'A',
+        custom2: 42,
+        username: 'testuser',
+      });
+      expect(originalServer).to.equal('https://icm-dev.internal');
+    });
+  });
+
+
 });


### PR DESCRIPTION
added controller, client, service and tests for /generatePortalForm endpoint 