### PR TITLE
(ADO-3435) increase request limit in .env.local to 200kb

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,7 +1,7 @@
 APP_ID=kiln-api
 PORT=3000
 LOG_LEVEL=debug
-REQUEST_LIMIT=100kb
+REQUEST_LIMIT=200kb
 SESSION_SECRET=mySecret
 
 #Swagger


### PR DESCRIPTION
Increases the REQUEST_LIMIT in .env.local from 100kb to 200kb