### PR TITLE
remove rewrite since API expects /api/

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -277,7 +277,6 @@ nginx:
         location = /health { return 200; }
 
         location /api/ {
-            rewrite ^/api(/.*)$ $1 break;
             proxy_pass http://kiln-api-svc:3000;
             
             #Debug proxyhost


### PR DESCRIPTION
remove rewrite in nginx since API expects /api/