### PR TITLE
Propagate orginalServer to Comm layer on Save

### DIFF
--- a/server/api/controllers/communications.controller.ts
+++ b/server/api/controllers/communications.controller.ts
@@ -283,6 +283,7 @@ export class CommunicationsController {
   }
 
   async saveFormData(req: AuthenticatedRequest, res: Response): Promise<void> {
+    const originalServer = req.headers['x-original-server'] as string;
     try {
       const {
         action,
@@ -305,7 +306,8 @@ export class CommunicationsController {
           items,
           sessionParams,
         },
-        token
+        token,
+        originalServer
       );
 
       if (result.success) {

--- a/server/api/services/icm.service.ts
+++ b/server/api/services/icm.service.ts
@@ -7,6 +7,7 @@ interface SaveICMDataPayload {
   savedForm: any;
   token?: string;
   username?: string;
+  originalServer?: string;
 }
 
 interface SaveICMDataRequest {
@@ -14,6 +15,7 @@ interface SaveICMDataRequest {
   OfficeName: string;
   username?: string;
   savedForm: any;
+  originalServer?: string;
 }
 
 interface SaveICMDataResult {
@@ -236,7 +238,8 @@ export class ICMService {
 
   async saveICMData(
     data: SaveICMDataRequest,
-    token?: string
+    token?: string,
+    originalServer?: string
   ): Promise<SaveICMDataResult> {
     try {
       const { attachmentId, OfficeName, username, savedForm } = data;
@@ -254,6 +257,7 @@ export class ICMService {
         attachmentId,
         OfficeName,
         savedForm,
+        originalServer
       };
 
       if (token) {
@@ -865,7 +869,8 @@ export class ICMService {
 
   async saveFormData(
     data: SaveFormDataRequest,
-    token?: string
+    token?: string,
+    originalServer?: string
   ): Promise<SaveFormDataResult> {
     try {
       const {
@@ -901,6 +906,7 @@ export class ICMService {
           OfficeName: sessionParams.OfficeName,
           username: sessionParams.username,
           savedForm: JSON.stringify(savedData),
+          originalServer
         },
         token
       );


### PR DESCRIPTION
Propagate originalServer to Comm layer on Save. Currently the header is not being saved so the AppConfig on Communication Layer does not pick up the employee URL.