### PR TITLE
Fix Background Generate Form

### DIFF
--- a/server/api/controllers/communications.controller.ts
+++ b/server/api/controllers/communications.controller.ts
@@ -67,6 +67,11 @@ export class CommunicationsController {
 
     if (result.success) {
       const boundData = await ICMService.bindFormData(result.data);
+      // Preserve params from original response for generate flow
+      // Communication-Layer stores attachmentId, OfficeName, etc. in params
+      if (result.data?.params) {
+        boundData.params = result.data.params;
+      }
       res.status(200).json(boundData);
     } else {
       res.status(result.status || 500).json({ error: result.error });


### PR DESCRIPTION
Preserve params from the original response for the generate flow, as the Communication-Layer stores attachmentId, OfficeName, etc. in params.