### PR TITLE
Updated logging to match pino syntax

### DIFF
--- a/server/api/middleware/auth.middleware.ts
+++ b/server/api/middleware/auth.middleware.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import logger from '../../common/logger';
+import L from '../../common/logger';
 
 export interface AuthenticatedRequest extends Request {
   user?: {
@@ -32,9 +32,7 @@ export function extractAuth(
 
     
     if (!token && !username) {
-      logger.error('Authentication required', {
-        route: req.path,
-      });
+      L.error({route: req.path}, 'Authentication required');
       res.status(401).json({
         error: 'Authentication required: provide either token or username'
       });
@@ -52,16 +50,16 @@ export function extractAuth(
     else if (req.params?.username) usernameSource = 'params';
     else if (req.cookies?.username) usernameSource = 'cookie';
 
-    logger.debug('Auth extracted', {
+    L.debug({
       hasToken: !!token,
       username: username || 'anonymous',
       usernameSource,
       route: req.path,
-    });
+    },'Auth extracted');
 
     next();
   } catch (error) {
-    logger.error('Error extracting auth:', error);
+    L.error({err: error}, 'Error extracting auth');
     res.status(500).json({ error: 'Authentication processing failed' });
   }
 }
@@ -72,7 +70,7 @@ export function validateAuth(
   next: NextFunction
 ): void {
   if (!req.user) {
-    logger.warn('No user context found, running extractAuth first');
+    L.warn('No user context found, running extractAuth first');
     return extractAuth(req, res, next);
   }
 

--- a/server/api/services/icm.client.ts
+++ b/server/api/services/icm.client.ts
@@ -16,7 +16,7 @@ interface ICMBlobResponse {
 
 export class ICMClient {
   private handleJsonError(error: any, operationName: string): ICMJsonResponse {
-    L.error(`ICMClient ${operationName} request failed:`, error);
+    L.error({ err: error }, `ICMClient ${operationName} request failed:`);
 
     if (error && typeof error === 'object' && 'response' in error) {
       const axiosError = error as any;
@@ -32,7 +32,7 @@ export class ICMClient {
   }
 
   private handleBlobError(error: any, operationName: string): ICMBlobResponse {
-    L.error(`ICMClient ${operationName} request failed:`, error);
+    L.error({ err: error }, `ICMClient ${operationName} request failed:`);
 
     if (error && typeof error === 'object' && 'response' in error) {
       const axiosError = error as any;
@@ -157,7 +157,7 @@ export class ICMClient {
           headers['X-Original-Server'] = originalServer;
         }
 
-        L.info('unlockICMData outgoing', { url, headers, payload });
+        L.info({ url, headers, payload }, 'unlockICMData outgoing');
       const response = await axios.post(url, payload, {
         headers,
         timeout,

--- a/server/api/services/icm.service.ts
+++ b/server/api/services/icm.service.ts
@@ -209,7 +209,7 @@ export class ICMService {
         ? error
         : 'Unknown error occurred';
 
-    L.error(errorMessage, error);
+    L.error({err: error}, errorMessage);
 
     return {
       success: false,
@@ -231,7 +231,7 @@ export class ICMService {
     } else {
       const errorData = (await response.json().catch(() => ({}))) as any;
       const errorMessage = errorData?.error || defaultErrorMessage;
-      L.error('ICMClient API Error:', errorMessage);
+      L.error({ err: errorMessage },'ICMClient API Error');
       return {
         success: false,
         error: errorMessage,
@@ -254,7 +254,7 @@ export class ICMService {
         data: pdfData,
       };
     } else {
-      L.error('PDF generation failed:', defaultErrorMessage);
+      L.error({ err: defaultErrorMessage}, 'PDF generation failed:');
       return {
         success: false,
         error: defaultErrorMessage,
@@ -572,7 +572,7 @@ export class ICMService {
         bound: true,
       };
     } catch (error) {
-      L.error('Error binding form data:', error);
+      L.error({ err: error }, 'Error binding form data');
       return this.handleError(error, 'Failed to bind form data');
     }
   }

--- a/server/common/server.ts
+++ b/server/common/server.ts
@@ -4,7 +4,7 @@ import bodyParser from 'body-parser';
 import http from 'http';
 import os from 'os';
 import cookieParser from 'cookie-parser';
-import l from './logger';
+import L from './logger';
 
 import installValidator from './swagger';
 
@@ -75,7 +75,7 @@ export default class ExpressServer {
         http.createServer(app).listen(port, welcome(port));
       })
       .catch((e) => {
-        l.error(e);
+        L.error(e);
         process.exit(1);
       });
 


### PR DESCRIPTION
Pino expects the error object to be the first parameter followed by the message. Also modified the logger reference to be consistent throughout (ie. use "L" for logger) 