### PR TITLE
Added missing "staging-latest" tag for nginx container

### DIFF
--- a/.github/workflows/publish-kiln-api-container.yml
+++ b/.github/workflows/publish-kiln-api-container.yml
@@ -45,7 +45,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=test-latest,enable=${{ github.ref == 'refs/heads/test' }}
-             type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' }}
+            type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' }}
             type=raw,value=dev-latest,enable=${{ github.ref == 'refs/heads/dev' }}
             type=sha,format=short
             type=ref,event=tag # e.g., v1.0.0

--- a/.github/workflows/publish-nginx-container.yml
+++ b/.github/workflows/publish-nginx-container.yml
@@ -46,6 +46,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=test-latest,enable=${{ github.ref == 'refs/heads/test' }}
+            type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' }}
             type=raw,value=dev-latest,enable=${{ github.ref == 'refs/heads/dev' }}
             type=sha,format=short
             type=ref,event=tag


### PR DESCRIPTION
Added missing "staging-latest" tag for nginx container since Openshift is unable to pull the image without this tag.